### PR TITLE
mimic standard behaviour more closely

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,13 +20,17 @@ module.exports = crap;
  */
 
 function crap(dir, fn){
-  fn = fn || onerror;
   assert(dir, 'directory name is required');
   assert(fs.existsSync(dir), 'directory name must exist');
-  process.once('uncaughtException', function(err){
-    heapdump.writeSnapshot(path.join(dir, filename()));
-    fn(err);
-  });
+  var origEmit = process.emit;
+  process.emit = function (type) {
+    if (type === 'uncaughtException') {
+      heapdump.writeSnapshot(path.join(dir, filename()));
+    }
+
+    return origEmit.apply(this, arguments);
+  };
+  fn && process.once('uncaughtException', fn);
 };
 
 /**
@@ -40,20 +44,4 @@ function filename(){
   var now = Date.now();
   var nanos = process.hrtime()[1];
   return util.format('crap-%s-%s.heapsnapshot', now, nanos);
-}
-
-/**
- * Default error handler that will log the stacktrace to
- * stderr and then exit the process.
- *
- * @param {Error} err
- * @api private
- */
-
-function onerror(err){
-  console.error(err.stack);
-  setTimeout(function(){
-    console.log('exiting -- crap!');
-    process.exit(1);
-  }, 1000);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,21 @@ var path = require('path');
 var glob = require('glob');
 var fs = require('fs');
 
+function runChild(file, cb) {
+  var app = spawn('node', [path.join(__dirname, file)]);
+  var stdout = [], stderr = [];
+  app.stdout.on('data', stdout.push.bind(stdout));
+  app.stderr.on('data', stderr.push.bind(stderr));
+  app.on('error', cb);
+  app.on('exit', function(code) {
+    cb(null, {
+      code: code,
+      stdout: Buffer.concat(stdout),
+      stderr: Buffer.concat(stderr)
+    });
+  });
+}
+
 describe('oh-crap', function(){
   after(function(done){
     var pattern = path.join(__dirname, '/*.heapsnapshot');
@@ -16,19 +31,17 @@ describe('oh-crap', function(){
   });
 
   it('should call the user provided error handler', function(done){
-    var app = spawn('node', [path.join(__dirname, 'app-handler.js')]);
-    app.stdout.once('data', function(data){
-      assert(data.toString() === 'bye!\n');
-    });
-    app.on('exit', function(code){
-      assert(code === 1);
+    runChild('app-handler.js', function(err, app) {
+      assert.ifError(err);
+      assert.equal(app.stdout.toString(), 'bye!\n');
+      assert.equal(app.code, 1);
       done();
     });
   });
 
   it('should write the snapshot', function(done){
-    var app = spawn('node', [path.join(__dirname, 'app-handler.js')]);
-    app.on('exit', function(code){
+    runChild('app-handler.js', function(err, app) {
+      assert.ifError(err);
       var pattern = path.join(__dirname, '/*.heapsnapshot');
       glob(pattern, function(err, files){
         if (err) return done(err);
@@ -39,15 +52,10 @@ describe('oh-crap', function(){
   });
 
   it('should use the internal handler by default', function(done){
-    var app = spawn('node', [path.join(__dirname, 'app-defaults.js')]);
-    app.stdout.once('data', function(data){
-      assert(data.toString() === 'exiting -- crap!\n');
-    });
-    app.stderr.once('data', function(data){
-      assert(data.toString().split('\n')[0] === 'Error: ahh');
-    });
-    app.on('exit', function(code){
-      assert(code === 1);
+    runChild('app-defaults.js', function(err, app) {
+      assert.ifError(err);
+      assert(/Error: ahh/.test(app.stderr.toString()));
+      assert.notEqual(app.code, 0);
       done();
     });
   });


### PR DESCRIPTION
Change the behaviour of crap so that it lets node.js deal with printing the error and exiting.

If backwards compatibility is desired, the following should do it.

``` diff
 ...
-function crap(dir){
+function crap(dir, fn){
 ...
+  fn && process.once('uncaughtException', fn);
 ...
```
